### PR TITLE
Character types

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -152,7 +152,7 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
         }
     }
 
-    function mint(uint256 numToMint, string calldata jobTitle)
+    function mint(uint256 numToMint)
         public
         payable
         nonReentrant

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -47,6 +47,15 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
     // ~~~ ====> Admin
     address public withdrawalAddress;
     mapping(address => uint256) private addressMintCounts;
+
+    string[] private tokenTypes = [
+        "architect",
+        "captain",
+        "explorer",
+        "journalist",
+        "mechanic",
+        "merchant"
+    ];
     mapping(uint256 => string) public tokenTypeMapping;
 
     constructor(
@@ -117,15 +126,19 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
     }
 
     modifier isAcceptedType(string calldata jobTitle) {
-        require(
-            keccak256(abi.encodePacked(jobTitle)) ==
-                keccak256(abi.encodePacked("artist")) ||
+        bool unknownType = true;
+
+        for (uint256 index = 0; index < tokenTypes.length; index++) {
+            if (
                 keccak256(abi.encodePacked(jobTitle)) ==
-                keccak256(abi.encodePacked("collector")) ||
-                keccak256(abi.encodePacked(jobTitle)) ==
-                keccak256(abi.encodePacked("mechanic")),
-            "Unknown character!"
-        );
+                keccak256(abi.encodePacked(tokenTypes[index]))
+            ) {
+                unknownType = false;
+                break;
+            }
+        }
+
+        require(unknownType != true, "Unknown character!");
         _;
     }
 

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -46,7 +46,7 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
 
     // ~~~ ====> Admin
     address public withdrawalAddress;
-    mapping(address => uint256) addressMintCounts;
+    mapping(address => uint256) private addressMintCounts;
 
     constructor(
         uint256 maxFoundingCrewSize,
@@ -66,15 +66,12 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
 
     // ~~~ ====> Modifiers
     modifier crewSpotsAvailable() {
-        require(
-            currentTokenId.current() <= MAX_CREW_SIZE,
-            "There are no more spots available on this expedition."
-        );
+        require(currentTokenId.current() <= MAX_CREW_SIZE, "No more spots!");
         _;
     }
 
     modifier isPreboardingOpen() {
-        require(preboarding, "We aren't boarding yet, space sailor!");
+        require(preboarding, "Not boarding yet, space sailor!");
         _;
     }
 

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -47,6 +47,7 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
     // ~~~ ====> Admin
     address public withdrawalAddress;
     mapping(address => uint256) private addressMintCounts;
+    mapping(uint256 => string) public tokenTypeMapping;
 
     constructor(
         uint256 maxFoundingCrewSize,
@@ -115,6 +116,19 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
         _;
     }
 
+    modifier isAcceptedType(string calldata jobTitle) {
+        require(
+            keccak256(abi.encodePacked(jobTitle)) ==
+                keccak256(abi.encodePacked("artist")) ||
+                keccak256(abi.encodePacked(jobTitle)) ==
+                keccak256(abi.encodePacked("collector")) ||
+                keccak256(abi.encodePacked(jobTitle)) ==
+                keccak256(abi.encodePacked("mechanic")),
+            "Unknown character!"
+        );
+        _;
+    }
+
     // ~~~ ====> Mint
     function preMint(
         uint256 numToMint,
@@ -128,10 +142,12 @@ contract Nexus is ERC721URIStorage, IERC2981, Ownable, ReentrancyGuard {
         isPreboardingOpen
         canEnlistEarly(numToMint, msg.sender, merkleProof)
         doesNotExceedLimit(msg.sender, numToMint)
+        isAcceptedType(jobTitle)
     {
         for (uint256 i = 0; i < numToMint; i++) {
             _safeMint(msg.sender, currentTokenId.current());
             addressMintCounts[msg.sender] += 1;
+            tokenTypeMapping[currentTokenId.current()] = jobTitle;
             currentTokenId.increment();
         }
     }

--- a/test/index.ts
+++ b/test/index.ts
@@ -383,10 +383,16 @@ describe("Nexus", function () {
     for (let index = 1; index < 3; index++) {
       const type = await this.nexus.tokenTypeMapping(index);
 
-      if (index === 1) {
-        expect(type).to.be.equal("mechanic");
-      } else if (index === 2) {
-        expect(type).to.be.equal("artist");
+      switch (index) {
+        case 1:
+          expect(type).to.be.equal("mechanic");
+          break;
+        case 2:
+          expect(type).to.be.equal("artist");
+          break;
+        case 3:
+          expect(type).to.be.equal("collector");
+          break;
       }
     }
   });

--- a/test/index.ts
+++ b/test/index.ts
@@ -103,7 +103,7 @@ describe("Nexus", function () {
 
     await expectRevert.unspecified(
       this.nexus.connect(addr1).preMint(1, proof, "engineer"),
-      "We aren't boarding yet, space sailor!"
+      "Not boarding yet, space sailor!"
     );
   });
 
@@ -299,7 +299,7 @@ describe("Nexus", function () {
       this.nexus.connect(addr3).mint(11, "engineer", {
         value: ethers.utils.parseEther("0.99"),
       }),
-      "There are no more spots available on this expedition."
+      "No more spots!"
     );
   });
 


### PR DESCRIPTION
This PR adds the following:
- We can now determine a `jobTitle` when minting during the pre-sale
- We store this in the contract state `mapping(tokenId => jobTitle)`
- Programatically, we'll fetch this post-preMint, prior to reveal